### PR TITLE
OGL Abstraction: copy and move constructors on buffers

### DIFF
--- a/src/opengl/Buffer.cc
+++ b/src/opengl/Buffer.cc
@@ -7,7 +7,8 @@ namespace GL
     Buffer::Buffer(unsigned int bufferType, void* buffer, unsigned int bufferSize, unsigned int drawType)
         : 
         BufferType(bufferType),
-        DrawType(drawType)
+        DrawType(drawType),
+        BufferSize(bufferSize)
     {
         glGenBuffers(1, &BufferID);
         SetData(buffer, bufferSize);
@@ -20,6 +21,17 @@ namespace GL
     {
         glGenBuffers(1, &BufferID);
     }
+
+    Buffer::Buffer(const Buffer& other) {
+        // Prepare the buffers
+        glBindBuffer(GL_COPY_READ_BUFFER, BufferID);
+        glBufferData(GL_COPY_READ_BUFFER, 0, nullptr, GL_STATIC_DRAW);
+        glBindBuffer(GL_COPY_WRITE_BUFFER, other.BufferID);
+
+        // Transfer the data from one buffer to the other
+        glCopyBufferSubData(GL_COPY_READ_BUFFER, GL_COPY_WRITE_BUFFER, 0, 0, BufferSize);
+    }
+
     Buffer::~Buffer()
     {
         glDeleteBuffers(1, &BufferID);

--- a/src/opengl/Buffer.cc
+++ b/src/opengl/Buffer.cc
@@ -32,6 +32,13 @@ namespace GL
         glCopyBufferSubData(GL_COPY_READ_BUFFER, GL_COPY_WRITE_BUFFER, 0, 0, BufferSize);
     }
 
+    Buffer::Buffer(const Buffer&& other) {
+        BufferID = other.BufferID;
+        BufferType = BufferType;
+        DrawType = other.DrawType;
+        BufferSize = other.BufferSize;
+    }
+
     Buffer::~Buffer()
     {
         glDeleteBuffers(1, &BufferID);

--- a/src/opengl/Buffer.hh
+++ b/src/opengl/Buffer.hh
@@ -7,6 +7,7 @@ namespace GL
     public:
         Buffer(unsigned int bufferType, void* buffer, unsigned int bufferSize, unsigned int drawType);
         Buffer(unsigned int bufferType, unsigned int drawType);
+        Buffer(const Buffer& other);
         ~Buffer();
 
         void Bind();
@@ -18,6 +19,7 @@ namespace GL
         unsigned int BufferID;
         unsigned int BufferType;
         unsigned int DrawType;
+        unsigned int BufferSize;
     protected:
     };
 }

--- a/src/opengl/Buffer.hh
+++ b/src/opengl/Buffer.hh
@@ -8,6 +8,7 @@ namespace GL
         Buffer(unsigned int bufferType, void* buffer, unsigned int bufferSize, unsigned int drawType);
         Buffer(unsigned int bufferType, unsigned int drawType);
         Buffer(const Buffer& other);
+        Buffer(const Buffer&& other);
         ~Buffer();
 
         void Bind();


### PR DESCRIPTION
As mentioned on issue #7, copy constructions are not implemented, what can lead into double deletions on buffers.

Copy and move constructors have been added to buffer objects. Other objects like shaders and textures have no trivial way of copying data directly on the GPU, and download and later upload would slow things a lot.